### PR TITLE
Fix for 6E colocated APs breaking BSSID output

### DIFF
--- a/WLANMon.ps1
+++ b/WLANMon.ps1
@@ -508,7 +508,8 @@ Do{
 
     # BSSID
     $BSSID_line = $output | Select-String -Pattern 'BSSID'
-    $BSSIDText = ($BSSID_line -split ":", 2)[-1].Trim()
+    $BSSID_line2 = (($BSSID_line -split [Environment]::NewLine)[0])
+    $BSSIDText = (($BSSID_line2 -split ":", 2)[-1].Trim())
     $BSSID.text = $BSSIDText
 
     # NetworkType


### PR DESCRIPTION
Win 11/6E introduces output with the string "band" to show co-located APs, this breaks the original scripts parsing for BSSID, and incorrectly shows the band. This patch fixes it.